### PR TITLE
Add Dockerfiles and build/run guide for SnapATAC2

### DIFF
--- a/.github/workflows/build_test_publish_docker_images.yml
+++ b/.github/workflows/build_test_publish_docker_images.yml
@@ -1,0 +1,90 @@
+# From https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+
+name: Build, Test, and Publish Docker images
+
+# Trigger on *publish* of a release
+# See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+on:
+  release:
+    types: [published]
+
+jobs:
+  matrixed-docker-build-test-publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        base-docker-image: ["python:3.11-slim"]
+        snap-atac-flavor: ["default", "recommend-interactive"]
+    steps:
+      # This will get the version of SnapATAC2 by looking at the the name of the tag for the github release
+      # For `on release publish` workflows `github.ref` will be the release tag created (e.g. refs/tags/<tag_name>)
+      # See: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+      - name: Get SnapATAC version
+        run: echo "SNAP_ATAC_VERSION=$(echo ${{ github.ref }} | cut -d "/" -f 3)" >> $GITHUB_ENV
+      # This makes some assumptions about `base-docker-image` name format so be sure to test this out if
+      # things change. For `python:3.11-slim` this should result in `PY_VER_ABBRV=py3.11` beings saved to $GITHUB_ENV
+      # See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+      - name: Get python version shorthand
+        run: echo "PY_VER_ABBRV=py$(echo ${{ matrix.base-docker-image }} | cut -d ":" -f 2 | cut -d "-" -f 1)" >> $GITHUB_ENV
+      # Should result in something like: `IMAGE_TAG=2.5.1-default-py3.11` or `IMAGE_TAG=2.5.1-recommend-interactive-py3.11`
+      - name: Create Docker image tag
+        run: echo "IMAGE_TAG=${{ env.SNAP_ATAC_VERSION }}-${{ matrix.snap-atac-flavor }}-${PY_VER_ABBRV}" >> $GITHUB_ENV
+      # Check environment variables were set properly
+      - name: Check ENV variables
+        run: |
+          echo "SNAP_ATAC_VERSION: ${{ env.SNAP_ATAC_VERSION }}"
+          echo "PY_VER_ABBRV: ${{ env.PY_VER_ABBRV }}"
+          echo "IMAGE_TAG: ${{ env.IMAGE_TAG }}"
+      # https://github.com/actions/checkout
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      # TODO: Has SnapATAC2 been tested for arm64? If it has and it works then uncomment the following
+      #       section and also add `linux/arm64` to `platforms` in subsequent steps:
+      # # https://github.com/docker/setup-qemu-action
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
+      # https://github.com/docker/build-push-action
+      # Uses github actions cache: https://docs.docker.com/build/cache/backends/gha/
+      - name: Build Dockerfile
+        uses: docker/build-push-action@v5
+        with:
+          context: docker/${{ matrix.snap-atac-flavor }}
+          build-args: |
+            BASE_PYTHON_IMAGE=${{ matrix.base-docker-image }}
+            SNAP_ATAC_VERSION=${{ env.SNAP_ATAC_VERSION }}
+          load: true
+          tags: snapatac2:TEST-${{ env.IMAGE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      # Mount the Github Workspace (repository root) into our test container
+      # Then install test required packages and run SnapATAC2 Python tests
+      - name: Test Docker Image
+        run: |
+          docker run --rm -t \
+            --entrypoint /bin/bash \
+            --volume "${{ github.workspace }}":"/github/workspace" \
+            snapatac2:TEST-${{ env.IMAGE_TAG }} \
+            -c "python3 -m pip install pytest hypothesis && pytest /github/workspace/snapatac2-python/tests"
+      # https://github.com/docker/login-action
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # https://github.com/docker/build-push-action
+      # Uses cached result from first build
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v5
+        with:
+          context: docker/${{ matrix.snap-atac-flavor }}
+          platforms: linux/amd64
+          build-args: |
+            BASE_PYTHON_IMAGE=${{ matrix.base-docker-image }}
+            SNAP_ATAC_VERSION=${{ env.SNAP_ATAC_VERSION }}
+          push: true
+          tags: snapatac2:${{ env.IMAGE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,55 @@
+SnapATAC2 Dockerfiles
+=====================
+
+These Dockerfiles are provided to help make SnapATAC2 more portable and easy to use. 
+
+The [snapatac2-default Dockerfile](./default/Dockerfile) is intended to be a useful
+starting point for running SnapATAC2 at scale (via HPC or in the Cloud).
+
+The [snapatac2-recommend-interactive Dockerfile](./recommend-interactive/Dockerfile)
+is intended to provide a ready to use Jupyter Lab notebook environment with SnapATAC2 and
+recommended packages (scanpy + scvi-tools) installed.
+
+## Pulling pre-built SnapATAC2 Dockerfiles
+
+- Prebuilt versions of these Dockerfiles can be found at: (TBA)
+
+## Building SnapATAC2 Dockerfiles
+
+### Build Requirements
+
+- This guide assumes you have installed either [Docker Engine](https://docs.docker.com/engine/install/)
+  or [Docker Desktop](https://docs.docker.com/get-docker/) which includes Docker Engine.
+- The Docker Engine version should be at least 23.0 in order to support Docker [BuildKit](https://docs.docker.com/build/buildkit/) (you can check with `docker --version`)
+
+### Build Instructions
+
+This guide assumes you are building with `docker build` terminal commands
+
+1. To build, change directory to either the [default](./default/) or [recommend-interactive](./snapatac2-recommend-interactive/)
+
+2. Then run the build command:
+    - For the default flavor of snapatac2 run:
+        `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --tag snapatac2:v2.5.1-default-py3.11 .`
+    - For the recommend-interactive flavor of snapatac2 run:
+        `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --tag snapatac2:v2.5.1-recommend-interactive-py3.11 .`
+
+> [!NOTE]
+> You can also provide `BASE_PYTHON_IMAGE` and `SNAP_ATAC_VERSION` build args to customize the image that gets built.
+> As an example, if you want an image with python 3.1.2 and SnapATAC2 v2.5.0 you could run a build command like:
+> `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --build-arg BASE_PYTHON_IMAGE=python:3.12-slim --build-arg SNAP_ATAC_VERSION=v2.5.0 --tag snapatac2:v2.5.0-default-py3.12 .`
+
+> [!WARNING]
+> Depending on the version of BASE_PYTHON_IMAGE and SNAP_ATAC_VERSION, the
+> resulting images are *NOT* guaranteed to be well-tested or even functional!
+
+### Run Instructions for `snapatac2:v2.5.1-recommend-interactive-py3.11` Image
+
+Once the image has been built, you can run it with:
+
+`docker run --interactive --tty --rm --publish 8888:8888 --volume <path_to_notebooks_on_your_local_machine>:/home/jupyter/notebooks snapatac2:v2.5.1-recommend-interactive-py3.11`
+
+You can then navigate in your browser to the `http://127.0.0.1:8888/lab?token=<jupyter-lab-token>` link to access Jupyter Lab
+
+> [!NOTE]
+> You can learn more about the `docker run` command options from the [official Docker documentation](https://docs.docker.com/engine/reference/commandline/run/#usage)

--- a/docker/default/Dockerfile
+++ b/docker/default/Dockerfile
@@ -1,0 +1,38 @@
+# Example build command: `DOCKER_BUILDKIT=1 docker build --tag snapatac2:2.5.1-default-py3.11 .`
+# Use a 2-step build so our final image doesn't include bulky compile tools
+ARG BASE_PYTHON_IMAGE=python:3.11-slim
+ARG SNAP_ATAC_VERSION=v2.5.1
+FROM ${BASE_PYTHON_IMAGE} AS builder-image
+
+# https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG SNAP_ATAC_VERSION
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN mkdir /python-wheel-dir
+WORKDIR /python-wheel-dir
+
+# Install necessary dependencies to create wheels for all snapATAC2 dependencies
+RUN apt update \
+    && apt install -y \
+        build-essential \
+        zlib1g-dev
+
+RUN python3 -m pip install wheel \
+    && python3 -m pip wheel \
+        --wheel-dir=/python-wheel-dir \
+        "snapatac2==${SNAP_ATAC_VERSION}"
+
+# =================================================================================================
+# Second build stage. Results in a roughly 1.38 GB image.
+FROM ${BASE_PYTHON_IMAGE}
+
+# https://docs.docker.com/engine/reference/builder/#scope
+ARG SNAP_ATAC_VERSION
+
+# Mount our first stage builder-image *temporarily* and install from the compiled .whl files
+RUN --mount=type=bind,from=builder-image,source=/python-wheel-dir,target=/python-wheel-dir \
+    python3 -m pip install \
+        --no-index --no-cache-dir --find-links=/python-wheel-dir \
+        "snapatac2==${SNAP_ATAC_VERSION}"

--- a/docker/recommend-interactive/Dockerfile
+++ b/docker/recommend-interactive/Dockerfile
@@ -1,0 +1,47 @@
+# Example build command: `DOCKER_BUILDKIT=1 docker build --tag snapatac2:2.5.1-recommend-interactive-py3.11 .`
+# Use a 2-step build so our final image doesn't include bulky compile tools
+ARG BASE_PYTHON_IMAGE=python:3.11-slim
+ARG SNAP_ATAC_VERSION=v2.5.1
+FROM ${BASE_PYTHON_IMAGE} AS builder-image
+
+# https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG SNAP_ATAC_VERSION
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN mkdir /python-wheel-dir
+WORKDIR /python-wheel-dir
+
+# Install necessary dependencies to create wheels for all snapATAC2 dependencies
+RUN apt update \
+    && apt install -y \
+        build-essential \
+        zlib1g-dev
+
+RUN python3 -m pip install wheel \
+    && python3 -m pip wheel --wheel-dir=/python-wheel-dir \
+        "snapatac2[recommend]==${SNAP_ATAC_VERSION}" \
+        jupyterlab
+
+# =================================================================================================
+# Second build stage. Results in a roughly 7.03 GB image
+# (majority of size come from scvi-tools dependency via PyTorch and Nvidia CUDA packages).
+FROM ${BASE_PYTHON_IMAGE}
+
+# https://docs.docker.com/engine/reference/builder/#scope
+ARG SNAP_ATAC_VERSION
+
+# Mount our first stage builder-image *temporarily* and install from the compiled .whl files
+RUN --mount=type=bind,from=builder-image,source=/python-wheel-dir,target=/python-wheel-dir \
+    python3 -m pip install \
+        --no-index --no-cache-dir --find-links=/python-wheel-dir \
+        "snapatac2[recommend]==${SNAP_ATAC_VERSION}" \
+        jupyterlab
+
+RUN useradd --create-home --shell /bin/bash jupyter
+USER jupyter
+EXPOSE 8888
+
+WORKDIR /home/jupyter/notebooks
+ENTRYPOINT ["jupyter", "lab", "--notebook-dir=/home/jupyter/notebooks", "--ip=0.0.0.0", "--port=8888", "--no-browser"]


### PR DESCRIPTION
This PR adds a pair of Dockerfiles and a small guide for building/running them. The hope is that Docker images built with these Dockerfiles could eventually be made available on public image repositories like Docker Hub to make it even easier to use and get started with SnapATAC2.

Guide can be previewed at: https://github.com/njmei/SnapATAC2/tree/add-dockerfiles-and-guide/docker

Would also be happy to help add a Github Actions config template for building the images, testing, and then uploading them to a Docker Hub account. Setup of credentials and a Docker Hub account would need to done by the Ren Lab though.