### PR TITLE
Improve Docker images usability

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -55,7 +55,7 @@ This guide assumes you are building with `docker build` terminal commands
 
 1. Once the image has been built, you can run it with:
 
-`docker run --interactive --tty --rm --env LOCAL_USER_ID=`id -u $USER` --publish 8888:8888 --volume <path_to_local_machine_notebooks>:/notebooks --volume <path_where_you_want_data_saved>:/data snapatac2:v2.6.0-recommend-interactive-py3.11`
+```docker run --interactive --tty --rm --env LOCAL_USER_ID=`id -u $USER` --publish 8888:8888 --volume <path_to_local_machine_notebooks>:/notebooks --volume <path_where_you_want_data_saved>:/data snapatac2:v2.6.0-recommend-interactive-py3.11```
 
 2. You can then navigate in your browser to the `http://127.0.0.1:8888/lab?token=<jupyter-lab-token>` link to access Jupyter Lab
 
@@ -69,7 +69,7 @@ This guide assumes you are building with `docker build` terminal commands
 
 1. Similar to the above except you should add `--platform linux/amd64` to the `docker run` command like so:
 
-`docker run --platform linux/amd64 --interactive --tty --rm --env LOCAL_USER_ID=`id -u $USER` --publish 8888:8888 --volume <path_to_local_machine_notebooks>:/notebooks --volume <path_where_you_want_data_saved>:/data snapatac2:v2.6.0-recommend-interactive-py3.11`
+```docker run --platform linux/amd64 --interactive --tty --rm --env LOCAL_USER_ID=`id -u $USER` --publish 8888:8888 --volume <path_to_local_machine_notebooks>:/notebooks --volume <path_where_you_want_data_saved>:/data snapatac2:v2.6.0-recommend-interactive-py3.11```
 
 ### Run Instructions for `snapatac2:v2.6.0-recommend-interactive-py3.11` Image on Windows [EXPERIMENTAL]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,24 +30,30 @@ This guide assumes you are building with `docker build` terminal commands
 
 2. Then run the build command:
     - For the default flavor of snapatac2 run:
-        `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --tag snapatac2:v2.5.1-default-py3.11 .`
+        `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --tag snapatac2:v2.6.0-default-py3.11 .`
     - For the recommend-interactive flavor of snapatac2 run:
-        `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --tag snapatac2:v2.5.1-recommend-interactive-py3.11 .`
+        `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --tag snapatac2:v2.6.0-recommend-interactive-py3.11 .`
 
 > [!NOTE]
 > You can also provide `BASE_PYTHON_IMAGE` and `SNAP_ATAC_VERSION` build args to customize the image that gets built.
-> As an example, if you want an image with python 3.1.2 and SnapATAC2 v2.5.0 you could run a build command like:
-> `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --build-arg BASE_PYTHON_IMAGE=python:3.12-slim --build-arg SNAP_ATAC_VERSION=v2.5.0 --tag snapatac2:v2.5.0-default-py3.12 .`
+> As an example, if you want an image with python 3.1.2 and a different version of SnapATAC2 (e.g. v2.5.1) you could run a build command like:
+> `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --build-arg BASE_PYTHON_IMAGE=python:3.12-slim --build-arg SNAP_ATAC_VERSION=v2.5.1 --tag snapatac2:v2.5.1-default-py3.12 .`
 
 > [!WARNING]
 > Depending on the version of BASE_PYTHON_IMAGE and SNAP_ATAC_VERSION, the
 > resulting images are *NOT* guaranteed to be well-tested or even functional!
 
-### Run Instructions for `snapatac2:v2.5.1-recommend-interactive-py3.11` Image
+### Run Instructions for `snapatac2:v2.6.0-recommend-interactive-py3.11` Image
+
+> [!WARNING]
+> If you want the recommended image to make use of CUDA (GPU) functionality, you will need to separately install the Nvidia container toolkit.
+> [Official instructions can be found here (don't accidentally skip the Configuration section either!!)](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+> When invoking the `docker run` command you will also need to provide the `--gpus` arg.
+> You can read more about how to do this in the [official Docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu).
 
 Once the image has been built, you can run it with:
 
-`docker run --interactive --tty --rm --publish 8888:8888 --volume <path_to_notebooks_on_your_local_machine>:/home/jupyter/notebooks snapatac2:v2.5.1-recommend-interactive-py3.11`
+`docker run --interactive --tty --rm --env LOCAL_USER_ID=`id -u $USER` --publish 8888:8888 --volume <path_to_local_machine_notebooks>:/notebooks --volume <path_where_you_want_data_saved>:/data snapatac2:v2.6.0-recommend-interactive-py3.11`
 
 You can then navigate in your browser to the `http://127.0.0.1:8888/lab?token=<jupyter-lab-token>` link to access Jupyter Lab
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -43,7 +43,9 @@ This guide assumes you are building with `docker build` terminal commands
 > Depending on the version of BASE_PYTHON_IMAGE and SNAP_ATAC_VERSION, the
 > resulting images are *NOT* guaranteed to be well-tested or even functional!
 
-### Run Instructions for `snapatac2:v2.6.0-recommend-interactive-py3.11` Image
+## Running SnapATAC2 Docker Images
+
+### Run Instructions for `snapatac2:v2.6.0-recommend-interactive-py3.11` Image on Linux/MacOS (amd64)
 
 > [!WARNING]
 > If you want the recommended image to make use of CUDA (GPU) functionality, you will need to separately install the Nvidia container toolkit.
@@ -51,11 +53,37 @@ This guide assumes you are building with `docker build` terminal commands
 > When invoking the `docker run` command you will also need to provide the `--gpus` arg.
 > You can read more about how to do this in the [official Docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu).
 
-Once the image has been built, you can run it with:
+1. Once the image has been built, you can run it with:
 
 `docker run --interactive --tty --rm --env LOCAL_USER_ID=`id -u $USER` --publish 8888:8888 --volume <path_to_local_machine_notebooks>:/notebooks --volume <path_where_you_want_data_saved>:/data snapatac2:v2.6.0-recommend-interactive-py3.11`
 
-You can then navigate in your browser to the `http://127.0.0.1:8888/lab?token=<jupyter-lab-token>` link to access Jupyter Lab
+2. You can then navigate in your browser to the `http://127.0.0.1:8888/lab?token=<jupyter-lab-token>` link to access Jupyter Lab
 
 > [!NOTE]
 > You can learn more about the `docker run` command options from the [official Docker documentation](https://docs.docker.com/engine/reference/commandline/run/#usage)
+
+### Run Instructions for `snapatac2:v2.6.0-recommend-interactive-py3.11` Image on MacOS (arm64) [UNTESTED, EXPERIMENTAL]
+
+> [!WARNING]
+> This section is COMPLETELY UNTESTED so no guarantees that it will work at all
+
+1. Similar to the above except you should add `--platform linux/amd64` to the `docker run` command like so:
+
+`docker run --platform linux/amd64 --interactive --tty --rm --env LOCAL_USER_ID=`id -u $USER` --publish 8888:8888 --volume <path_to_local_machine_notebooks>:/notebooks --volume <path_where_you_want_data_saved>:/data snapatac2:v2.6.0-recommend-interactive-py3.11`
+
+### Run Instructions for `snapatac2:v2.6.0-recommend-interactive-py3.11` Image on Windows [EXPERIMENTAL]
+
+1. Install Docker Desktop for Windows: https://docs.docker.com/desktop/install/windows-install/
+2. Start up Docker Desktop for Windows
+3. Look for the snapatac2 image that you want to run and `pull` it
+4. Go back to the main images menu and 'run' the image
+
+<img src="docker-windows-tutorial-0.png" width=25% height=25%>
+5. Before clicking `run` open up the `optional settings` and fill in the following:
+
+<img src="docker-windows-tutorial-1.png" width=25% height=25%>
+6. A new container should be spun up and you should see in the `logs` section the following:
+
+<img src="docker-windows-tutorial-2.png" width=25% height=25%>
+7. Pasting the url in the `logs` section into your browser should let you access Jupyter Lab
+

--- a/docker/default/Dockerfile
+++ b/docker/default/Dockerfile
@@ -1,7 +1,7 @@
-# Example build command: `DOCKER_BUILDKIT=1 docker build --tag snapatac2:2.5.1-default-py3.11 .`
+# Example build command: `DOCKER_BUILDKIT=1 docker build --tag snapatac2:2.6.0-default-py3.11 .`
 # Use a 2-step build so our final image doesn't include bulky compile tools
 ARG BASE_PYTHON_IMAGE=python:3.11-slim
-ARG SNAP_ATAC_VERSION=v2.5.1
+ARG SNAP_ATAC_VERSION=v2.6.0
 FROM ${BASE_PYTHON_IMAGE} AS builder-image
 
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact

--- a/docker/docker-windows-tutorial-0.png
+++ b/docker/docker-windows-tutorial-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b0d17d19eb3f2c1b2a71a3452901875f52bfe869ced773f4c16c094be7a6f4d
+size 314511

--- a/docker/docker-windows-tutorial-1.png
+++ b/docker/docker-windows-tutorial-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:085030ef28511ee2d7b22221c10c86e105ed2dbbeab41afd02f1486e5af0d245
+size 107998

--- a/docker/docker-windows-tutorial-2.png
+++ b/docker/docker-windows-tutorial-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:785a729240eb59b95f75aac98c17fa3c447cd5a06563d6ab0d69f2fb3887d356
+size 541580

--- a/docker/recommend-interactive/Dockerfile
+++ b/docker/recommend-interactive/Dockerfile
@@ -1,7 +1,7 @@
-# Example build command: `DOCKER_BUILDKIT=1 docker build --tag snapatac2:2.5.1-recommend-interactive-py3.11 .`
+# Example build command: `DOCKER_BUILDKIT=1 docker build --tag snapatac2:2.6.0-recommend-interactive-py3.11 .`
 # Use a 2-step build so our final image doesn't include bulky compile tools
 ARG BASE_PYTHON_IMAGE=python:3.11-slim
-ARG SNAP_ATAC_VERSION=v2.5.1
+ARG SNAP_ATAC_VERSION=v2.6.0
 FROM ${BASE_PYTHON_IMAGE} AS builder-image
 
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
@@ -32,6 +32,15 @@ FROM ${BASE_PYTHON_IMAGE}
 # https://docs.docker.com/engine/reference/builder/#scope
 ARG SNAP_ATAC_VERSION
 
+# Install gosu to gracefully step-down from root in a Docker context
+# https://github.com/tianon/gosu/tree/master
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y gosu; \
+	rm -rf /var/lib/apt/lists/*; \
+    # verify that the binary works
+	gosu nobody true
+
 # Mount our first stage builder-image *temporarily* and install from the compiled .whl files
 RUN --mount=type=bind,from=builder-image,source=/python-wheel-dir,target=/python-wheel-dir \
     python3 -m pip install \
@@ -39,9 +48,15 @@ RUN --mount=type=bind,from=builder-image,source=/python-wheel-dir,target=/python
         "snapatac2[recommend]==${SNAP_ATAC_VERSION}" \
         jupyterlab
 
-RUN useradd --create-home --shell /bin/bash jupyter
-USER jupyter
-EXPOSE 8888
+# Use entrypoint that helps us step-down from root
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
-WORKDIR /home/jupyter/notebooks
-ENTRYPOINT ["jupyter", "lab", "--notebook-dir=/home/jupyter/notebooks", "--ip=0.0.0.0", "--port=8888", "--no-browser"]
+# Setup SnapATAC2 data download directory
+RUN mkdir -p /data
+ENV SNAP_DATA_DIR=/data
+
+WORKDIR /notebooks
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+EXPOSE 8888
+CMD ["jupyter", "lab", "--notebook-dir=/notebooks", "--ip=0.0.0.0", "--port=8888", "--no-browser"]

--- a/docker/recommend-interactive/entrypoint.sh
+++ b/docker/recommend-interactive/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Adapted from: https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
+
+# Add local user
+# Either use the LOCAL_USER_ID if passed in at runtime or
+# fallback
+
+USER_ID=${LOCAL_USER_ID:-9001}
+
+echo "Starting with UID : $USER_ID"
+useradd --shell /bin/bash -u $USER_ID -o -c "" -m user
+export HOME=/home/user
+
+exec gosu user "$@"

--- a/snapatac2-python/pyproject.toml
+++ b/snapatac2-python/pyproject.toml
@@ -57,6 +57,6 @@ Changelog = "https://kzhang.org/SnapATAC2/version/dev/changelog.html"
 
 [project.optional-dependencies]
 extra = ["scanorama>=1.7.3", "harmonypy>=0.0.9", "xgboost>=1.4", "umap-learn>=0.5.0"]
-recommend = ["scanpy>=1.9", "scvi-tools>=1.0"]
+recommend = ["scanpy[skmisc]>=1.9", "scvi-tools>=1.0"]
 all = ["snapatac2[extra]", "snapatac2[recommend]"]
 test = ["pytest", "hypothesis==6.72.4"]


### PR DESCRIPTION
This PR was originally intended to address: https://github.com/kaizhang/SnapATAC2/issues/238

But it turns out that the issue was with an upstream dependency (`scvi-tools`) that has since resolved the problem. So, I spent a bit of time further polishing the Docker images and guide and really making sure that the notebooks (especially the annotations.ipynb) work now.

Link to preview updated SnapATAC2 /docker README: https://github.com/njmei/SnapATAC2/tree/address-docker-issues/docker#snapatac2-dockerfiles

Highlights:
- Guide includes how to utilize GPU. I've verified that the example `annotations.ipynb` can make use of a GPU: 
<img src="https://github.com/kaizhang/SnapATAC2/assets/43766899/431b7d48-71bb-49bd-82dc-d5c580a69602" width=25% height=25%>

- Guide has been updated to show how to mount a data directory on the local machine and have SnapATAC save or load from it
- Added sections to the guide for how to run the Docker image on other platforms (Windows/MacOS)

Question:
I was looking to see if SnapATAC2 is now publishing Docker images for various new version releases, but I'm not seeing up to date images at: https://hub.docker.com/r/kaizhang/snapatac2. Is there anything I can do to help that process along?