### PR TITLE
Fix notebook bugs and dependency issues

### DIFF
--- a/docs/tutorials/integration.ipynb
+++ b/docs/tutorials/integration.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e3ddd3b0ab937f8f01182228c74221588ca62e97333c883173f6334775ce32e
-size 354519
+oid sha256:e7d78f0bd84be577a8ce17f5540b1abb31caa82cf7cea053f71e3de17806078a
+size 354516

--- a/snapatac2-python/pyproject.toml
+++ b/snapatac2-python/pyproject.toml
@@ -57,6 +57,6 @@ Changelog = "https://kzhang.org/SnapATAC2/version/dev/changelog.html"
 
 [project.optional-dependencies]
 extra = ["scanorama>=1.7.3", "harmonypy>=0.0.9", "xgboost>=1.4", "umap-learn>=0.5.0"]
-recommend = ["scanpy[skmisc]>=1.9", "scvi-tools>=1.0"]
+recommend = ["scanpy[scanorama, skmisc, magic, harmony]>=1.9", "scvi-tools>=1.0"]
 all = ["snapatac2[extra]", "snapatac2[recommend]"]
 test = ["pytest", "hypothesis==6.72.4"]

--- a/snapatac2-python/python/snapatac2/preprocessing/_scrublet.py
+++ b/snapatac2-python/python/snapatac2/preprocessing/_scrublet.py
@@ -255,7 +255,7 @@ def scrub_doublets_core(
     del count_matrix_sim
     gc.collect()
     _, evecs = spectral(
-        AnnData(X=merged_matrix, dtype=merged_matrix.dtype),
+        AnnData(X=merged_matrix),
         features=None,
         n_comps=n_comps,
         inplace=False,


### PR DESCRIPTION
This PR is partially in response to:
https://github.com/kaizhang/SnapATAC2/issues/277

Notes:
- I've now run all notebooks *except* [docs/tutorials/atlas.ipynb](https://github.com/kaizhang/SnapATAC2/blob/main/docs/tutorials/atlas.ipynb) to ensure they work properly.
    - The `atlas.ipynb` requires a bit too much data to download for me to test
- Please see individual commit messages for additional details

Questions:
- It looks like there is overlap in terms of how to install dependencies like `scanorama>=1.7.3` and `harmonypy>=0.0.9`. I see them in `extra` under `[project.optional-dependencies]` but would it make more sense to remove them from `extra` and just keep the ones I newly added under `recommend`? Or would you prefer the opposite (move packages like `magic-impute` to `extra`)?
    - It seems like it would be easier to let `scanpy` maintainers manage these dependences? (See: https://github.com/scverse/scanpy/blob/3ceb740ba37effc44f42ecdb884cef86a38d4346/pyproject.toml#L138-L151) Or are there strong reasons to have `snapatac2` manage these dependencies (even under `extra`)?