### PR TITLE
Fix failing docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         base-docker-image: ["python:3.11-slim"]
+        snap-atac-flavor: ["default", "recommend-interactive"]
     steps:
       # This makes some assumptions about `base-docker-image` name format so be sure to test this out if
       # things change. For `python:3.11-slim` this should result in `PY_VER_ABBRV=py3.11` beings saved to $GITHUB_ENV
@@ -22,7 +23,7 @@ jobs:
         run: echo "PY_VER_ABBRV=py$(echo ${{ matrix.base-docker-image }} | cut -d ":" -f 2 | cut -d "-" -f 1)" >> $GITHUB_ENV
       # Should result in something like: `IMAGE_TAG=2.5.1-default-py3.11` or `IMAGE_TAG=2.5.1-recommend-interactive-py3.11`
       - name: Create Docker image tag
-        run: echo "IMAGE_TAG=${{ inputs.version }}-${PY_VER_ABBRV}" >> $GITHUB_ENV
+        run: echo "IMAGE_TAG=${{ inputs.version }}-${{ matrix.snap-atac-flavor }}-${PY_VER_ABBRV}" >> $GITHUB_ENV
       # Check environment variables were set properly
       - name: Check ENV variables
         run: |
@@ -32,6 +33,8 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          lfs: true
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -45,7 +48,8 @@ jobs:
       - name: Build Dockerfile
         uses: docker/build-push-action@v5
         with:
-          context: docker/default
+          context: docker/${{ matrix.snap-atac-flavor }}
+          platforms: linux/amd64
           build-args: |
             BASE_PYTHON_IMAGE=${{ matrix.base-docker-image }}
             SNAP_ATAC_VERSION=${{ inputs.version }}
@@ -73,7 +77,7 @@ jobs:
       - name: Push to Docker Hub
         uses: docker/build-push-action@v5
         with:
-          context: docker/default
+          context: docker/${{ matrix.snap-atac-flavor }}
           platforms: linux/amd64
           build-args: |
             BASE_PYTHON_IMAGE=${{ matrix.base-docker-image }}


### PR DESCRIPTION
1. It turns out tests were failing because the github `actions/checkout` plugin by default does not download git LFS files. This was causing later tests to fail because they were expecting full test files instead of git LFS pointers.

2. This commit also restores the matrixed snap-atac-flavor options. Each run of the updated workflow will release `default` as well as a `recommend-interactive` snapatac2 docker image.

**Note**: tests in this PR are probably failing because it is still pointing at: `kaizhang/SnapATAC2/.github/workflows/docker.yml@main`

https://github.com/kaizhang/SnapATAC2/blob/b7854948133e7a1a59badcf53432fc57ef236f98/.github/workflows/test_python.yml#L47-L50

**Validation**:
On my fork, the `Test Docker Image` portion passes. Note that the login step fails (because I didn't set up docker credentials on my fork):
https://github.com/njmei/SnapATAC2/actions/runs/8503169951/job/23288304288