### PR TITLE
Add store_bdg, SPMR, broad parameters for calling peaks using MACS3

### DIFF
--- a/snapatac2-python/python/snapatac2/tools/_call_peaks.py
+++ b/snapatac2-python/python/snapatac2/tools/_call_peaks.py
@@ -21,6 +21,9 @@ def macs3(
     min_len: int | None = None,
     blacklist: Path | None = None,
     key_added: str = 'macs3',
+        broad: bool = False,
+        store_bdg: bool = False,
+        SPMR: bool = False,
     tempdir: Path | None = None,
     inplace: bool = True,
     n_jobs: int = 8,
@@ -68,6 +71,12 @@ def macs3(
         removed.
     key_added
         `.uns` key under which to add the peak information.
+    broad:
+        Call broad peak or not (by default False)
+    store_bdg:
+        Store bedgraph file or not (by default False). Note: this will capture large storage on disk.
+    SPMR:
+        Use signal per million reads for fragment pileup profiles (by default False), an option for storing bedgraph.
     tempdir
         If provided, a temporary directory will be created in the directory.
         Otherwise, a temporary directory will be created in the system default temporary directory.
@@ -105,8 +114,8 @@ def macs3(
     options.bdg_control = 'c'
     options.cutoff_analysis = False
     options.cutoff_analysis_file = 'a'
-    options.store_bdg = False
-    options.do_SPMR = False
+    options.store_bdg = store_bdg
+    options.do_SPMR = SPMR
     options.trackline = False
     options.log_pvalue = None
     options.log_qvalue = log(qvalue, 10) * -1
@@ -120,7 +129,7 @@ def macs3(
     options.smalllocal = 1000
     options.largelocal = 10000
     options.call_summits = True
-    options.broad = False
+    options.broad = broad
     options.fecutoff = 1.0
     options.d = extsize
     options.scanwindow = 2 * options.d


### PR DESCRIPTION
Hi Kai,

I add three parameters for peak calling. 
1. On bed graph generation:
   - SPMR and store_bdg, I open the two parameters since we notice that MACS2/3 can generate the smoothed bedgraphs for our later deep learning model usage. 

2. On broad peak calling:
   - add broad to allow broad peak calling. We typically use this for broad peak calling on some histone modifications. 

But I am not sure if this is enough for the peak calling function since I notice that you actually have a rust layer for the real task. 
Another question I have: there is `nomodel` parameter in the list. According the [MACS3 README](https://macs3-project.github.io/MACS/docs/callpeak.html), it seems to be needed for `extsize` parameter. 

By default, I set all of them false in order to keep the default behavior of your function.


Thanks!
Songpeng

